### PR TITLE
ARK-4 Changes

### DIFF
--- a/libya2d/ya2d_image.c
+++ b/libya2d/ya2d_image.c
@@ -25,9 +25,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
+#include <psputility.h>
 #include <png.h>
-#include <jpeglib.h>
 
+#ifdef USE_PSP_JPEG
+#include <pspjpeg.h>
+#else
+#include <jpeglib.h>
+#endif
 
 #define YA2D_PNGSIGSIZE   (8)
 #define YA2D_BMPSIGNATURE (0x4D42)
@@ -73,6 +78,7 @@ static void _ya2d_read_png_buffer_fn(png_structp png_ptr, png_bytep data, png_si
 
 static struct ya2d_texture* _ya2d_load_PNG_generic(void* io_ptr, png_rw_ptr read_data_fn, int place)
 {
+
     png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
                                                  NULL, NULL, NULL);
     if(png_ptr == NULL) {
@@ -336,6 +342,112 @@ exit_error:
     return NULL;    
 }
 
+
+#ifdef USE_PSP_JPEG
+
+static void get_JPEG_info(u8* data, int data_size, int* out_w, int* out_h){
+    int w = 0, h = 0;
+    const uint8_t * buf = &data[0];
+    for (int i = 2; i < data_size;) {
+        if (buf[i] == 0xFF) {
+            i++;
+            switch(buf[i]){
+                case 0xC0: case 0xC1: case 0xC2: case 0xC3: case 0xC5: case 0xC6: case 0xC7: case 0xC9: case 0xCA: case 0xCB: case 0xCD: case 0xCE: case 0xCF:
+                    i += 4;
+                    h = (buf[i] << 8) | (buf[i+1]);
+                    w = (buf[i+2] << 8) | (buf[i+3]);
+                    i = data_size; break;
+                case 0xDA: case 0xD9: break;
+                default:
+                    i += ((buf[i+1] << 8) | (buf[i+2])) + 1;
+                    break;
+            }
+        } else i++;
+    }
+    *out_w = w;
+    *out_h = h;
+}
+
+struct ya2d_texture* ya2d_load_JPEG_buffer(void* jpegbuf, unsigned long jpeg_size, int place){
+
+    struct ya2d_texture *texture = NULL;
+    void* bufRGB = NULL;
+    int w = 0, h = 0;
+    int res = -1;
+
+    int utility_loaded = sceUtilityLoadModule(PSP_MODULE_AV_MPEGBASE);
+    sceJpegInitMJpeg();
+
+    get_JPEG_info(jpegbuf, jpeg_size, &w, &h);
+    if (w <= 0 || h <= 0){
+        //printf("bad image: %dx%d\n", w, h);
+        goto ya2d_load_jpeg_error;
+    }
+
+    int w2 = next_pow2(w);
+    int h2 = next_pow2(h);
+
+    bufRGB = malloc(4*w2*h2);
+    texture = ya2d_create_texture(w, h, GU_PSM_8888, place);
+    if (!bufRGB || !texture){
+        //printf("alloc FAILED: %p, %p\n", bufRGB, texture);
+        goto ya2d_load_jpeg_error;
+    }
+
+    if ((res=sceJpegCreateMJpeg(w2, h2))<0) {
+        //printf("sceJpegCreateMJpeg FAILED: %p\n", res);
+        goto ya2d_load_jpeg_error;
+    }
+
+    if ((res=sceJpegDecodeMJpeg(jpegbuf, jpeg_size, bufRGB, 0)) < 0){
+        //printf("sceJpegCreateMJpeg FAILED: %p\n", res);
+        goto ya2d_load_jpeg_error;
+    }
+
+    unsigned char* tex_data = texture->data;
+    unsigned char* buf = bufRGB;
+    unsigned int wb = w2*4;
+    for (int i=0; i<h2; i++){
+        memcpy(tex_data, buf, wb);
+        buf += wb;
+        tex_data += texture->stride;
+    }
+    texture->has_alpha = 0;
+
+    ya2d_flush_texture(texture);
+
+    goto ya2d_load_jpeg_finish;
+
+    ya2d_load_jpeg_error:
+    ya2d_free_texture(texture); texture = NULL;
+
+    ya2d_load_jpeg_finish:
+    free(bufRGB);
+    sceJpegDeleteMJpeg();
+    sceJpegFinishMJpeg();
+    if (utility_loaded>=0) sceUtilityUnloadModule(PSP_MODULE_AV_MPEGBASE);
+
+    return texture;
+}
+
+struct ya2d_texture* ya2d_load_JPEG_file(const char* filename, int place){
+    SceUID fd = sceIoOpen(filename, PSP_O_RDONLY, 0777);
+    size_t filesize = sceIoLseek(fd, 0, PSP_SEEK_END);
+    sceIoLseek(fd, 0, PSP_SEEK_SET);
+
+    void* buf = malloc(filesize);
+    if (!buf) return NULL;
+
+    sceIoRead(fd, buf, filesize);
+    struct ya2d_texture* res = ya2d_load_JPEG_buffer(buf, filesize, place);
+
+    sceIoClose(fd);
+    free(buf);
+    return res;
+}
+
+#else
+
 static struct ya2d_texture* _ya2d_load_JPEG_generic(struct jpeg_decompress_struct* jinfo, struct jpeg_error_mgr* jerr, int place)
 {
     int row_bytes;
@@ -378,7 +490,6 @@ exit_error:
     return NULL;
 }
 
-
 struct ya2d_texture* ya2d_load_JPEG_file(const char* filename, int place)
 {
     FILE *fd;
@@ -403,7 +514,6 @@ struct ya2d_texture* ya2d_load_JPEG_file(const char* filename, int place)
     return texture;
 }
 
-
 struct ya2d_texture* ya2d_load_JPEG_buffer(void* buffer, unsigned long buffer_size, int place)
 {
     if (buffer == NULL) {
@@ -424,3 +534,5 @@ struct ya2d_texture* ya2d_load_JPEG_buffer(void* buffer, unsigned long buffer_si
     
     return texture;
 }
+
+#endif

--- a/libya2d/ya2d_image.h
+++ b/libya2d/ya2d_image.h
@@ -23,6 +23,8 @@
 #include "ya2d_texture.h"
 #include <pspkerneltypes.h>
 
+#define USE_PSP_JPEG 1
+
 struct ya2d_texture* ya2d_load_PNG_file(const char* filename, int place);
 struct ya2d_texture* ya2d_load_PNG_file_offset(const char* filename, int place, SceOff offset);
 struct ya2d_texture* ya2d_load_PNG_buffer(void* buffer, int place);

--- a/libya2d/ya2d_main.c
+++ b/libya2d/ya2d_main.c
@@ -81,7 +81,10 @@ int ya2d_init()
     
     sceDisplayWaitVblankStart();
     sceGuDisplay(GU_TRUE);
-        
+    
+    sceGuFinish();
+    sceGuSync(GU_SYNC_WHAT_DONE, GU_SYNC_FINISH);
+    
     _ya2d_inited = 1;
     return 1;
 }

--- a/libya2d/ya2d_texture.c
+++ b/libya2d/ya2d_texture.c
@@ -32,7 +32,7 @@
 static struct ya2d_texture *ya2d_create_texture_common(int width, int height, int pixel_format)
 {
     struct ya2d_texture *texture = (struct ya2d_texture *)malloc(sizeof(struct ya2d_texture));
-    if (!texture) return NULL;
+    if (texture == NULL) return NULL;
     
     texture->width  = width;
     texture->height = height;
@@ -62,7 +62,7 @@ static struct ya2d_texture *ya2d_create_texture_common(int width, int height, in
 struct ya2d_texture *ya2d_create_texture(int width, int height, int pixel_format, int place)
 {
     struct ya2d_texture *texture = ya2d_create_texture_common(width, height, pixel_format);
-    if (texture) {
+    if (texture != NULL) {
         //If there's not enough space in the VRAM, then allocate it in the RAM
         if ((place == YA2D_PLACE_RAM) || (texture->data_size > vlargestblock())) {
             texture->data = memalign(16, texture->data_size);
@@ -91,22 +91,27 @@ struct ya2d_texture *ya2d_create_empty_texture(int width, int height, int pixel_
 
 void ya2d_free_texture(struct ya2d_texture *texture)
 {
-    if (texture->place == YA2D_PLACE_RAM) {
-        free(texture->data);
-    } else if (texture->place == YA2D_PLACE_VRAM){
-        vfree(texture->data);
+    if (texture) {
+        if (texture->data){
+            if (texture->place == YA2D_PLACE_RAM) {
+                free(texture->data);
+            } else if (texture->place == YA2D_PLACE_VRAM){
+                vfree(texture->data);
+            }
+        }
+        free(texture);
     }
-    free(texture);
 }
 
 void ya2d_set_texture(struct ya2d_texture *texture)
 {
-    sceGuEnable(GU_TEXTURE_2D);
-    sceGuTexMode(texture->pixel_format, 0, 0, texture->swizzled);
-    sceGuTexImage(0, texture->pow2_w, texture->pow2_h,
-                  texture->pow2_w, texture->data);
-    sceGuTexFunc(GU_TFX_REPLACE, texture->has_alpha ? GU_TCC_RGBA : GU_TCC_RGB);
-    sceGuTexFilter(GU_NEAREST, GU_NEAREST);   
+    if (texture){
+        sceGuEnable(GU_TEXTURE_2D);
+        sceGuTexMode(texture->pixel_format, 0, 0, texture->swizzled);
+        sceGuTexImage(0, texture->pow2_w, texture->pow2_h, texture->pow2_w, texture->data);
+        sceGuTexFunc(GU_TFX_REPLACE, texture->has_alpha ? GU_TCC_RGBA : GU_TCC_RGB);
+        sceGuTexFilter(GU_NEAREST, GU_NEAREST);
+    }
 }
 
 static inline void _ya2d_draw_texture_slow(struct ya2d_texture *texture, int x, int y, int center_x, int center_y)
@@ -128,7 +133,7 @@ static inline void _ya2d_draw_texture_slow(struct ya2d_texture *texture, int x, 
     sceGumDrawArray(GU_SPRITES, GU_TEXTURE_16BIT|GU_VERTEX_16BIT|GU_TRANSFORM_2D, 2, 0, vertices);
 }
 
-static void _ya2d_draw_texture_fast(struct ya2d_texture *texture, int x, int y, int center_x, int center_y)
+static inline void _ya2d_draw_texture_fast(struct ya2d_texture *texture, int x, int y, int center_x, int center_y)
 {    
     int i, k, slice, n_slices = texture->width/YA2D_TEXTURE_SLICE;
     if (texture->width%YA2D_TEXTURE_SLICE != 0) ++n_slices;
@@ -153,11 +158,22 @@ static void _ya2d_draw_texture_fast(struct ya2d_texture *texture, int x, int y, 
 
 void ya2d_draw_texture(struct ya2d_texture *texture, int x, int y)
 {
-    ya2d_draw_texture_hotspot(texture, x, y, 0, 0); 
+    if (texture){
+        if (!texture->has_alpha && texture->pixel_format == GU_PSM_8888)
+            ya2d_draw_texture_blend(texture, x, y, 0xFF000000);
+        else
+            ya2d_draw_texture_hotspot(texture, x, y, 0, 0); 
+    }
 }
 
-void ya2d_draw_texture_blend(struct ya2d_texture *texture, int x, int y, unsigned int color)
+void ya2d_draw_texture_blend(struct ya2d_texture *texture, int x, int y, unsigned int color){
+    ya2d_draw_texture_blend_scale(texture, x, y, color, 1.f, 1.f);
+}
+
+void ya2d_draw_texture_blend_scale(struct ya2d_texture *texture, int x, int y, unsigned int color, float scale_x, float scale_y)
 {
+    if (!texture) return;
+
     ya2d_set_texture(texture);
     
     struct ya2d_vertex_1ui2s3s *vertices = sceGuGetMemory(2 * sizeof(struct ya2d_vertex_1ui2s3s));
@@ -172,8 +188,8 @@ void ya2d_draw_texture_blend(struct ya2d_texture *texture, int x, int y, unsigne
     vertices[1].color = color;
     vertices[1].u = texture->width;
     vertices[1].v = texture->height;
-    vertices[1].x = x + texture->width;
-    vertices[1].y = y + texture->height;
+    vertices[1].x = x + (texture->width)*scale_x;
+    vertices[1].y = y + (texture->height)*scale_y;
     vertices[1].z = 0;
     
     sceGumDrawArray(GU_SPRITES, GU_COLOR_8888|GU_TEXTURE_16BIT|GU_VERTEX_16BIT|GU_TRANSFORM_2D, 2, 0, vertices);
@@ -186,18 +202,23 @@ void ya2d_draw_texture_centered(struct ya2d_texture *texture, int x, int y)
 
 void ya2d_draw_texture_hotspot(struct ya2d_texture *texture, int x, int y, int center_x, int center_y)
 {
+    if (!texture) return;
+
     ya2d_set_texture(texture);
-    
-    //There's no need to use the fast algorithm with small textures
     if (texture->width > YA2D_TEXTURE_SLICE) {
         _ya2d_draw_texture_fast(texture, x, y, center_x, center_y);
-    } else {
+    } else { //There's no need to use the fast algorithm with small textures
         _ya2d_draw_texture_slow(texture, x, y, center_x, center_y);
     }    
 }
 
 void ya2d_draw_texture_scale(struct ya2d_texture *texture, int x, int y, float scale_x, float scale_y)
 {
+    if (!texture) return;
+
+    if (!texture->has_alpha && texture->pixel_format == GU_PSM_8888)
+        ya2d_draw_texture_blend_scale(texture, x, y, 0xFF000000, scale_x, scale_y);
+
     ya2d_set_texture(texture);
 
     struct ya2d_vertex_2s3s *vertices = sceGuGetMemory(2 * sizeof(struct ya2d_vertex_2s3s));
@@ -224,6 +245,8 @@ void ya2d_draw_texture_rotate(struct ya2d_texture *texture, int x, int y, float 
 
 void ya2d_draw_texture_rotate_hotspot(struct ya2d_texture *texture, int x, int y, float angle, int center_x, int center_y)
 {
+    if (!texture) return;
+
     ya2d_set_texture(texture);
 
     struct ya2d_vertex_2s3s *vertices = sceGuGetMemory(4 * sizeof(struct ya2d_vertex_2s3s));
@@ -268,13 +291,14 @@ void ya2d_draw_texture_rotate_hotspot(struct ya2d_texture *texture, int x, int y
 
 void ya2d_flush_texture(struct ya2d_texture *texture)
 {
-    sceKernelDcacheWritebackRange(texture->data, texture->data_size);
+    if (texture)
+        sceKernelDcacheWritebackRange(texture->data, texture->data_size);
 }
 
 void ya2d_swizzle_texture(struct ya2d_texture *texture)
 {
     //There's no need to use swizzle with small textures
-    if(texture->swizzled || texture->width < YA2D_TEXTURE_SLICE) return;
+    if(!texture || texture->swizzled || texture->width < YA2D_TEXTURE_SLICE) return;
     void *tmp = malloc(texture->data_size);
     swizzle_fast(tmp, texture->data, texture->stride, texture->pow2_h);
     memcpy(texture->data, tmp, texture->data_size);

--- a/libya2d/ya2d_texture.h
+++ b/libya2d/ya2d_texture.h
@@ -52,6 +52,7 @@ void ya2d_draw_texture_centered(struct ya2d_texture *texture, int x, int y);
 void ya2d_draw_texture_hotspot(struct ya2d_texture *texture, int x, int y, int center_x, int center_y);
 
 void ya2d_draw_texture_scale(struct ya2d_texture *texture, int x, int y, float scale_x, float scale_y);
+void ya2d_draw_texture_blend_scale(struct ya2d_texture *texture, int x, int y, unsigned int color, float scale_x, float scale_y);
 
 void ya2d_draw_texture_rotate(struct ya2d_texture *texture, int x, int y, float angle);
 void ya2d_draw_texture_rotate_hotspot(struct ya2d_texture *texture, int x, int y, float angle, int center_x, int center_y);


### PR DESCRIPTION
This PR contains all changes (so far) done to the library in the ARK-4 project.

- Added NULL checks to improve stability of the library.
- Fixed drawing of textures that have no alpha channel.
- Added the ability to use Sony's JPEG decoder instead of libjpeg: lowers image compatibility but greatly reduces library size (strips off 200KB) and decoding speed (decoding is offloaded to ME/Kermit as opposed to main CPU with libjpeg). NOTE: you can still compile the library to use libjpeg instead.