### PR TITLE
Fix for latest sdk

### DIFF
--- a/libya2d/ya2d_image.c
+++ b/libya2d/ya2d_image.c
@@ -17,16 +17,18 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "ya2d_image.h"
-#include "ya2d_texture.h"
-#include "ya2d_utils.h"
-#include <pspiofilemgr.h>
-#include <pspgu.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
+#include <string.h>
+#include <pspiofilemgr.h>
+#include <pspgu.h>
 #include <psputility.h>
 #include <png.h>
+
+#include "ya2d_image.h"
+#include "ya2d_texture.h"
+#include "ya2d_utils.h"
 
 #ifdef USE_PSP_JPEG
 #include <pspjpeg.h>

--- a/libya2d/ya2d_main.c
+++ b/libya2d/ya2d_main.c
@@ -48,9 +48,9 @@ int ya2d_init()
     
     sceGuStart(GU_DIRECT, _ya2d_gu_list);
     
-    _ya2d_fb[0] = valloc(BUF_WIDTH * SCR_HEIGHT * 4);
-    _ya2d_fb[1] = valloc(BUF_WIDTH * SCR_HEIGHT * 4);
-    _ya2d_zfb   = valloc(BUF_WIDTH * SCR_HEIGHT * 2);
+    _ya2d_fb[0] = vramalloc(BUF_WIDTH * SCR_HEIGHT * 4);
+    _ya2d_fb[1] = vramalloc(BUF_WIDTH * SCR_HEIGHT * 4);
+    _ya2d_zfb   = vramalloc(BUF_WIDTH * SCR_HEIGHT * 2);
     
     _ya2d_drawfbp = _ya2d_fb[0];
     


### PR DESCRIPTION
This allows the library to compile with latest PSP SDK, we need this so we can add this library to psp-packages (https://github.com/pspdev/psp-packages).